### PR TITLE
Documentation in Eng. (w.r.t. Notion)

### DIFF
--- a/_i18n/en/about/about.md
+++ b/_i18n/en/about/about.md
@@ -17,19 +17,17 @@ The goal of the OSORI project is to contribute to building a more transparent an
 - Steering Committee: Eunkyung Hwang, Younghwan Kim (both from Kakao), Kyoungae Kim, Soim Kim (both from LG Electronics), Moonki Hong, Yoonhwan Jung (both from Samsung Electronics)
 - Project Manager: Soim Kim (LG Electronics)
 
-## Logo introduction (TBD)
-
 ## History
 1. First ever proposal of the OSORI project
-   - Date and Place: '22.3.16. @ OpenChain Korea Work Group
+   - Date and Place: 2022.3.16. @ OpenChain Korea Work Group
    - Participants: open source delegation from companies such as Kakao, LG Electronics, Samsung Electronics, Hyundai AutoEver, Hyundai Motors, Kakao Bank, Line Plus, NCsoft, SK Holdings, SKT, etc.
 2. Kick-off meeting
-   - Date and place: '23.1.19. @ Samsung Electronics Seoul R&D Campus
+   - Date and place: 2023.1.19. @ Samsung Electronics Seoul R&D Campus
    - Participants: Kakao, LG Electronics, Samsung Electronics
 3. MOU ceremony (Press Release Distribution)
-   - Date and Place: '23.4.26. @Korea Copyright Commission Seoul Office
+   - Date and Place: 2023.4.26. @Korea Copyright Commission Seoul Office
    - Attendees: Ministry of Culture, Sports and Tourism, Korea Copyright Commission, Kakao, LG Electronics, Samsung Electronics 
 4. OSORI presentation in public
-   - '23.8.31 @ Sharing Works and Open Source SW License Conference, Soim Kim and Yoonhwan Jung
-   - '23.10.11 @ EOST, Yoonhwan Jung
-   - '23.11.15 @ SDC23 Korea, Soim Kim and Younghwan Kim
+   - 2023.8.31 @ Sharing Works and Open Source SW License Conference, Soim Kim and Yoonhwan Jung
+   - 2023.10.11 @ EOST, Yoonhwan Jung
+   - 2023.11.15 @ SDC23 Korea, Soim Kim and Younghwan Kim

--- a/_i18n/en/about/charter.md
+++ b/_i18n/en/about/charter.md
@@ -1,44 +1,58 @@
-# Charter
-{: .fs-9 }
-
-Just the Docs gives your documentation a jumpstart with a responsive Jekyll theme that is easily customizable and hosted on GitHub Pages.
-{: .fs-6 .fw-300 }
-
-[Get started now](#getting-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
-[View it on GitHub][Just the Docs repo]{: .btn .fs-5 .mb-4 .mb-md-0 }
-
----
-
-{: .warning }
-> This website documents the features of the current `main` branch of the Just the Docs theme. See the CHANGELOG for a list of releases, new features, and bug fixes.
-
-Just the Docs is a theme for generating static websites with [Jekyll]. You can write source files for your web pages using [Markdown], the [Liquid] templating language, and HTML.[^1] Jekyll builds your site by converting all files that have [front matter] to HTML. Your [Jekyll configuration] file determines which theme to use, and sets general parameters for your site, such as the URL of its home page.
-
-Jekyll builds this Just the Docs theme docs website using the theme itself. These web pages show how your web pages will look *by default* when you use this theme. But you can easily *customize* the theme to make them look completely different!
-
-Browse the docs to learn more about how to use this theme.
-
-## Getting started
-
-The [Just the Docs Template] provides the simplest, quickest, and easiest way to create a new website that uses the Just the Docs theme. To get started with creating a site, just click "[use the template]"!
+# Project Charter
 
 {: .note }
-To use the theme, you do ***not*** need to clone or fork the [Just the Docs repo]! You should do that only if you intend to browse the theme docs locally, contribute to the development of the theme, or develop a new theme based on Just the Docs.
+[**Project Application Form (in Korean)**](https://www.notion.so/1c245a5d54c547ffaf4b1afb87c4e113?pvs=21)
 
-You can easily set the site created by the template to be published on [GitHub Pages] – the [template README] file explains how to do that, along with other details.
+## Name
+The project name is "오소리 _(in Korean)_". 오소리 means "open source sound!", and is written in English as OSORI (Open Source DB Integration).
 
-If [Jekyll] is installed on your computer, you can also build and preview the created site *locally*. This lets you test changes before committing them, and avoids waiting for GitHub Pages.[^2] And you will be able to deploy your local build to a different platform than GitHub Pages.
+## Goal
+The goal of the OSORI project is to contribute to building a more transparent and reliable open source ecosystem by integrating and disclosing open source information data (e.g. license and any restriction to use), so that anyone can easily check it out.
 
+## Vision
+- We build a DB schema that efficiently integrates open source information data, of which is easy to manage and distribute consistently.
+- We increase the reliability of the data through cross-validation and disclose it for its complimentary usage by anyone.
+- We expand volume of the data through voluntary contributions by providing an environment where anyone can easily contribute their data to the OSORI project.
 
-[Jekyll]: https://jekyllrb.com
-[Markdown]: https://daringfireball.net/projects/markdown/
-[Liquid]: https://github.com/Shopify/liquid/wiki
-[Front matter]: https://jekyllrb.com/docs/front-matter/
-[Jekyll configuration]: https://jekyllrb.com/docs/configuration/
-[source file for this page]: https://github.com/just-the-docs/just-the-docs/blob/main/index.md
-[Just the Docs Template]: https://just-the-docs.github.io/just-the-docs-template/
-[Just the Docs]: https://just-the-docs.com
-[Just the Docs repo]: https://github.com/just-the-docs/just-the-docs
-[GitHub Pages]: https://pages.github.com/
-[Template README]: https://github.com/just-the-docs/just-the-docs-template/blob/main/README.md
-[use the template]: https://github.com/just-the-docs/just-the-docs-template/generate
+## License Policy
+1. Open source information data: ODC-By 1.0 License (Open Data Commons Attribution License v1.0)
+2. Source code: Apache 2.0 License
+3. Contents excluding the open source information data and the source code: CC-BY-2.0 License
+
+## Membership Composition
+
+1. **User**
+   - As a user of the OSORI project, anyone can use the open source information data and other contents as defined in Section of "License Policy" without any additional procedures such as membership application.
+
+2. **Member (Corporate/Individual)**
+   - To contribute the open source information data to the OSORI project, you shall be Member of the project. Any applicant who want to be Member shall submit [**Project Application Form**](https://www.notion.so/1c245a5d54c547ffaf4b1afb87c4e113?pvs=21) and get approval from Steering Committee of the OSORI project. A definition of Steering Committee is described in a below Section of "Organization" in detail.
+   - The applicant can submit the Project Application Form document as Individual in the membership application process. However, if the applicant wants to contribute the data owned by their corporation or institution, they shall join the OSORI project as Corporate Members and require to submit the Project Application Form as Corporate.
+
+3. **Board Member**
+   - Corporate Member can become Board Member if their data contribution to the OSORI project is huge and significant. The initial Board Members are Samsung Electronics, LG Electronics, and Kakao who are founding Corporate Members of this project.
+   - Additional Board Member can be appointed through approval process from Steering Committee.
+   - Each Board Member can assign upto two representatives in the Steering Committee.
+
+4. **Sponsor**
+   - Any corporations or institutions, who support the OSORI project in various manners such as the project operation, related service development and deployment, can become Sponsor of the OSORI project. The applicant can become Sponsor by getting approval from Steering Committee after the applicant's submission of Project Sponsor Application Form.
+   - Sponsor can post their corporation name and logo onto the OSORI project website, and can use a brand name and logo of the OSORI project for their promotion in public.
+
+## Organization
+1. **Steering Committee (SC)**
+   - Role and Responsibility
+     - Steering Committee makes major decisions such as policies and schedules of the project.
+     - Steering Committee reviews and approves applications for being Member, Board Member, and Sponsors.
+     - Steering Committee appoints Project Manager (PM) through an election. 
+     - Steering Committee can write and amend Charter of the OSORI project.
+   - Composition
+     - Steering Committee is composed of Steering Committee members assigned by each Board Member. Each Board Member can nominate upto two Steering Committee members as their representative.
+     - The term of office as the initial Steering Committee member shall be valid until December 31, 2024. After that, the term of office shall be one year. A Steering Committee member may serve his or her term consecutively.
+
+2. **Project Manager (PM)**
+   - Role and Responsibility
+     - Project Manager organizes meetings of Steering Committee.
+     - Project Manager is responsible for public communication on behalf of the OSORI project.
+   - Composition
+     - Project Manager is elected through a vote among Steering Committee members.
+     - The initial Project Manager is Soim Kim (LG Electronics), and her term of office is until December 31, 2024.
+     - Project Manager can be reappointed, and its seat number can be increased if necessary.

--- a/_i18n/en/guide/api-doc.md
+++ b/_i18n/en/guide/api-doc.md
@@ -1,44 +1,315 @@
-# API Doc
-{: .fs-9 }
+# User APIs
 
-Just the Docs gives your documentation a jumpstart with a responsive Jekyll theme that is easily customizable and hosted on GitHub Pages.
-{: .fs-6 .fw-300 }
-
-[Get started now](#getting-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
-[View it on GitHub][Just the Docs repo]{: .btn .fs-5 .mb-4 .mb-md-0 }
+This section explains how to use the APIs provided by the OSORI project to users.
 
 ---
 
-{: .warning }
-> This website documents the features of the current `main` branch of the Just the Docs theme. See the CHANGELOG for a list of releases, new features, and bug fixes.
+{:.warning }
+> **Limitations on the API usage**: the user APIs are restricted to use under the condition below.<br>
+**If more than 5,000 API calls are attempted in an hour, we block its usage due to Too Many Request exception.**
 
-Just the Docs is a theme for generating static websites with [Jekyll]. You can write source files for your web pages using [Markdown], the [Liquid] templating language, and HTML.[^1] Jekyll builds your site by converting all files that have [front matter] to HTML. Your [Jekyll configuration] file determines which theme to use, and sets general parameters for your site, such as the URL of its home page.
+## Inquiry for the license list
 
-Jekyll builds this Just the Docs theme docs website using the theme itself. These web pages show how your web pages will look *by default* when you use this theme. But you can easily *customize* the theme to make them look completely different!
+### `/api/v1/licenses`
 
-Browse the docs to learn more about how to use this theme.
+{:.note }
+**This is an API that can retrieve data about the licenses provided from the OSORI project.**
 
-## Getting started
+#### Query parameters in the API
 
-The [Just the Docs Template] provides the simplest, quickest, and easiest way to create a new website that uses the Just the Docs theme. To get started with creating a site, just click "[use the template]"!
+| Parameter name | Detail description |
+| --- | --- |
+| name | License name <br> ex. MIT License |
+| spdxIdentifier | SPDX license identifier <br> ex. MIT |
+| webpage | A URL address for the license notice<br> ex. https://opensource.org/licenses/MIT |
+| equalFlag | Used when specifying the target of search results.<br> - 'Y': Displays the results from exactly matching a keyword <br> - 'N' (default value): Displays all the results containing the keyword |
+| modifiedDate | Date of modification |
+| page | The number of start page (mandatory) <br> - Default value: 0 |
+| size | The number of retrieved data from the page (mandatory) |
+| sort | Sorting criteria in terms of data entity (mandatory) <br> The available entities for the criteria are as follows. <br> - name <br> - nickname <br> - id <br> - version <br> - oss_version_id |
+| direction | Sorting order <br> - ASC: Ascending (default value) <br> - DESC: Descending |
 
-{: .note }
-To use the theme, you do ***not*** need to clone or fork the [Just the Docs repo]! You should do that only if you intend to browse the theme docs locally, contribute to the development of the theme, or develop a new theme based on Just the Docs.
+#### Usage example
+curl --location --request GET '[https://{osiri_base_url}](http://223.255.204.223:8081/api/v1/licenses?modifiedDate=&equalFlag=&page=&size=&sort=&direction=&name=&spdxIdentifier=&webpage=)**`/api/v1/licenses?name=MIT%20License&equalFlag=Y&page=0&size=1&sort=name&direction=ASC`**
 
-You can easily set the site created by the template to be published on [GitHub Pages] – the [template README] file explains how to do that, along with other details.
+#### Header in response
+Content-Type application/json
 
-If [Jekyll] is installed on your computer, you can also build and preview the created site *locally*. This lets you test changes before committing them, and avoids waiting for GitHub Pages.[^2] And you will be able to deploy your local build to a different platform than GitHub Pages.
+#### Body in response (JSON)
+```json
+{
+    "code": "200",
+    "messageList": {
+        "list": [
+            {
+                "id": 24,
+                "name": "MIT License",
+                "obligation_disclosing_src": "NONE",
+                "obligation_notification": true,
+                "osi_approval": false
+            }
+        ],
+        "count": 1
+    },
+    "success": true
+}
+```
 
+#### Details in the response body
 
-[Jekyll]: https://jekyllrb.com
-[Markdown]: https://daringfireball.net/projects/markdown/
-[Liquid]: https://github.com/Shopify/liquid/wiki
-[Front matter]: https://jekyllrb.com/docs/front-matter/
-[Jekyll configuration]: https://jekyllrb.com/docs/configuration/
-[source file for this page]: https://github.com/just-the-docs/just-the-docs/blob/main/index.md
-[Just the Docs Template]: https://just-the-docs.github.io/just-the-docs-template/
-[Just the Docs]: https://just-the-docs.com
-[Just the Docs repo]: https://github.com/just-the-docs/just-the-docs
-[GitHub Pages]: https://pages.github.com/
-[Template README]: https://github.com/just-the-docs/just-the-docs-template/blob/main/README.md
-[use the template]: https://github.com/just-the-docs/just-the-docs-template/generate
+| **Name** | **Description** |
+| --- | --- |
+| code | Code value for a response status of the API<br> 200: Success |
+| id | ID of the target retrieved data (primary key) |
+| name | License name |
+| obligation_disclosing_src | Scope of source code disclosure in distribution <br> - NONE <br> - ORIGINAL <br> - FILE <br> - MODULE <br> - LIBRARY <br> - DERIVATIVE WORK <br> - EXECUTABLE <br> - DATA <br> - SOFTWARE USING THIS <br>- UNSPECIFIED |
+| obligation_notification | Obligation of notification in distribution <br> - false: No obligation <br> - true: Obligates notification in its distribution |
+| osi_approval | Whether or not the license has been approved by OSI (https://opensource.org/licenses/) |
+| count | Total number of the retrieved data |
+| success | Call result of the API <br> - false: Failure <br> - true: Success |
+
+## Inquiry for detail information of the license
+
+### `/api/v1/licenses/{category}?searchWord={seaarch keyword}`
+
+{:.note }
+**This is an API that allows you to retrieve detail information about the licenses provided from the OSORI project.**
+
+#### Query parameters in the API
+
+| Parameter name | Detail description |
+| --- | --- |
+| category | Select the data entity for your search<br> - name<br> - spdx_identifier<br> - url |
+| searchWord | Enter the keyword for your search<br> ex. MIT |
+
+#### Usage example
+curl --location --request GET '[https://{osiri_base_url}](http://223.255.204.223:8081/api/v1/licenses?modifiedDate=&equalFlag=&page=&size=&sort=&direction=&name=&spdxIdentifier=&webpage=)/api/v1/licenses/spdx_identifier?searchWord=MIT 
+
+#### Header in response
+Content-Type application/json
+
+#### Body in response (JSON)
+```json
+{
+  "code": "200",
+  "messageList": {
+    "detailInfo": [
+      {
+        "id": 63,
+        "name": "MIT License",
+        "obligation_disclosing_src": "NONE",
+        "obligation_notification": true,
+        "spdx_identifier": "MIT",
+        "webpage": null,
+        "description": "To distribute the software, copyright and license notice is required.\n\n",
+        "description_ko": null,
+        "license_text": "Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.",
+        "osi_approval": false,
+        "modifier": "soim",
+        "created_date": "2023-10-16 10:08:58",
+        "modified_date": "2023-10-17 21:51:33",
+        "reviewed": true,
+        "nicknameList": [
+          "Bouncy Castle Licence",
+          "The MIT License",
+          "The MIT License (MIT)"
+        ],
+        "webpageList": [
+          "https://spdx.org/licenses/MIT.html"
+        ],
+        "restrictionList": null
+      }
+    ]
+  },
+  "success": true
+}
+```
+
+#### Details in the response body
+
+| **Name** | **Description** |
+| --- | --- |
+| code | Code value for a response status of the API<br> 200: success |
+| id | ID of the target retrieved data (primary key) |
+| name | License name |
+| obligation_disclosing_src | Scope of source code disclosure in distribution<br> - NONE<br> - ORIGINAL<br> - FILE<br> - MODULE<br> - LIBRARY<br> - DERIVATIVE WORK<br> - EXECUTABLE<br> - DATA<br> - SOFTWARE USING THIS<br> - UNSPECIFIED |
+| obligation_notification | Obligation of notification in distribution<br> - false : no notification obligation<br> - true : notification obligation exists |
+| spdx_idetifier | A name of SPDX identifier |
+| webpage | A URL address for the license notice |
+| description | Description of the license |
+| license_text | License notice text |
+| osi_approval | Whether or not the license has been approved by OSI (https://opensource.org/licenses/) |
+| reviewed | Review status of the license (in OSORI)<br> - false: not reviewed<br> - true: review completed |
+| nicknameList | List of nicknames for the license |
+| webpageList | List of alternative URLs aside from webpage, such as sources of license notices |
+| restrictionList | List of restrictions imposed by the license |
+
+## Inquiry for the Open Source software (OSS) List
+
+### `/api/v1/oss`
+
+{:.note }
+**This is an API that allows you to retrieve open source information provided from the OSORI project.**
+
+#### Query parameters in the API
+
+| Parameter name | Detail description | 
+| --- | --- |
+| ossName | Open Source name |
+| version | Open Source version information |
+| downloadLocation | A URL for downloading the given Open Source<br> ex. github/aerogear-attic/aerogear-android-stor |
+| equalFlag | Used when specifying the target of search results.<br> - 'Y': Displays the results from exactly matching a keyword <br> - 'N' (default value): Displays all the results containing the keyword |
+| modifiedDate | Date of modification |
+| page | The number of start page (mandatory) <br> - Default value: 0 |
+| size | The number of retrieved data from the page (mandatory) |
+| sort | Sorting criteria in terms of data entity (mandatory) <br> The available entities for the criteria are as follows. <br> - name <br> - nickname <br> - id <br> - version <br> - oss_version_id |
+| direction | Sorting order <br> - ASC: Ascending (default value) <br> - DESC: Descending |
+
+#### Usage example
+curl --location --request GET '[https://{osiri_base_url}](http://223.255.204.223:8081/api/v1/licenses?modifiedDate=&equalFlag=&page=&size=&sort=&direction=&name=&spdxIdentifier=&webpage=)**`/api/v1/oss?ossName=android&equalFlag=Y&page=0&size=10&sort=name&direction=ASC`**
+
+#### Header in response
+Content-Type application/json
+
+#### Body in response (JSON)
+```json
+{
+    "code": "200",
+    "messageList": {
+        "list": [
+            {
+                "oss_master_id": 8681,
+                "name": "aerogear-android-store",
+                "version": [
+                    {
+                        "version": "4.0.0",
+                        "version_id": "8259",
+                        "declaredLicense": null
+                    }
+                ],
+                "version_license_diff": "false",
+                "purl": "pkg:github/aerogear-attic/aerogear-android-store"
+            }
+        ],
+        "count": 1
+    },
+    "success": true
+}
+```
+
+#### Details in the response body
+
+| **Name** | **Description** |
+| --- | --- |
+| code | Code value for a response status of the API<br> 200: Success |
+| oss_master_id | ID of the target retrieved Open Source data (primary key) |
+| name | Open source name |
+| version_id | ID of the version for the given Open Source (primary key) |
+| version | Open Source version information |
+| declaredLicense | Representative license defined in the given Open Source version |
+| detectedLicense | Additional licenses detected aside from declaredLicense in the given Open Source version |
+| version_license_diff | True if its license is different according to the release version. |
+| purl | Package URL (purl) of the representative link to the given Open Source (https://github.com/package-url/purl-spec) |
+| count | Total number of the retrieved data |
+| success | Call result of the API <br> - false: Failure <br> - true: Success |
+
+## Inquiry for detail information of the Open Source
+
+### `/api/v1/oss/{category}/versions?searchWord={search keyword}`
+
+{:.note }
+**This is an API that allows you to retrieve detail information about the Open Source provided from the OSORI project.**
+
+#### Query parameters in the API
+
+| Parameter name | Detail description | 
+|---|---|
+| category | Select the data entity for your search<br> - name<br> download_location |
+| searchWord | Enter the keyword for your search<br> ex. facebook |
+
+#### Usage example
+curl --location --request GET 'https://{osiri_base_url}/api/v1/oss/name/versions?searchWord=facebook'
+
+#### Header in response
+Content-Type application/json
+
+#### Body in response (JSON)
+```json
+{
+  "code": "200",
+  "messageList": {
+    "detailInfo": {
+      "oss_master": [
+        {
+          "oss_master_id": 5901,
+          "name": "facebook",
+          "download_location": "https://github.com/huandu/facebook",
+          "purl": "pkg:github/huandu/facebook",
+          "homepage": null,
+          "description": null,
+          "compliance_notice": null,
+          "compliance_notice_ko": null,
+          "version_license_diff": false,
+          "attribution": null,
+          "publisher": null,
+          "downloadLocationList": [],
+          "purlList": [],
+          "nicknameList": [
+            "huandu/facebook"
+          ],
+          "modifier": "sean.gold",
+          "modified_date": "2023-10-20 17:08:26",
+          "created_date": "2023-10-20 17:08:25",
+          "oss_version": [
+            {
+              "oss_version_id": 14740,
+              "version": "2.3.1+incompatible",
+              "description": null,
+              "description_ko": null,
+              "attribution": null,
+              "license_combination": null,
+              "release_date": null,
+              "modifier": "sean.gold",
+              "declaredLicenseList": [
+                "MIT License"
+              ],
+              "detectedLicenseList": null,
+              "restrictionList": null,
+              "created_date": "2023-10-20 17:08:26",
+              "modified_date": "2023-10-20 17:08:26"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "success": true
+}
+```
+
+#### Details in the response body
+
+| **Name** | **Description** |
+| --- | --- |
+| code | Code value for a response status of the API<br> 200: Success |
+| oss_master_id | ID of the target retrieved Open Source data (primary key) |
+| name | Open source name |
+| download_location | A download URL for the given Open Source |
+| purl | Package URL (purl) of the representative link to the given Open Source (https://github.com/package-url/purl-spec) |
+| homepage | A URL of the official Open Source website |
+| description | Description of the Open Source |
+| compliance_notice | Summary description of the given Open Source in terms of compliance (value exists only when it has the compliance notice) |
+| version_license_diff | True if its license is different according to the release version. |
+| attribution | Matters requiring separate notification |
+| publisher | Distributor or owner (personel or organization) |
+| downloadLocationList | Additional links to download the given Open Source<br> ex. http://github.com |
+| nicknameList | List of alternative names indicating the given Open Source |
+| oss_version | A version list of the given Open Source |
+| oss_version_id | ID of the given Open Source version (primary key) |
+| version | Version information of the given Open Source (version name) |
+| description | Summary description of the given Open Source version (in English) |
+| attribution | Matters requiring separate notification |
+| license_combination | Logical relationship of dual or multiple licenses indicated in declaredLicenseList (possible values: AND, OR, null) |
+| declaredLicense | Representative license defined in the given Open Source version |
+| detectedLicense | Additional licenses detected aside from declaredLicense in the given Open Source version |
+| restrictionList | List of restrictions imposed by the given Open Source |

--- a/_i18n/en/guide/contribution-guide.md
+++ b/_i18n/en/guide/contribution-guide.md
@@ -1,44 +1,43 @@
 # Contribution Guide
-{: .fs-9 }
 
-Just the Docs gives your documentation a jumpstart with a responsive Jekyll theme that is easily customizable and hosted on GitHub Pages.
-{: .fs-6 .fw-300 }
+## Definition and Overview
+Contribution means any activity that participates in and contributes to the OSORI open source project. The OSORI project also aims to develop its data through various contribution activities.
 
-[Get started now](#getting-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
-[View it on GitHub][Just the Docs repo]{: .btn .fs-5 .mb-4 .mb-md-0 }
+This guide explains how to participate as a contributor in the OSORI project.
 
----
+## Preparation
+To contribute to the OSORI project, you must submit an application form for joining the project and follow the Code of Conduct (contribution method and format) in the contribution guide. In the OSORI project application form, there are items that must be agreed upon for contributions, which must be familiarized before making a contribution. Since it is carried out at the time of membership application in writing and agreeing to join the OSORI project, it is necessary to check out contents below if planning to proceed with the contribution.
 
-{: .warning }
-> This website documents the features of the current `main` branch of the Just the Docs theme. See the CHANGELOG for a list of releases, new features, and bug fixes.
+{:.note }
+**Details of the application form can be found here ([link](https://www.notion.so/1c245a5d54c547ffaf4b1afb87c4e113?pvs=21)).**
 
-Just the Docs is a theme for generating static websites with [Jekyll]. You can write source files for your web pages using [Markdown], the [Liquid] templating language, and HTML.[^1] Jekyll builds your site by converting all files that have [front matter] to HTML. Your [Jekyll configuration] file determines which theme to use, and sets general parameters for your site, such as the URL of its home page.
+## Types
+There are many ways to participate in the OSORI project, such as correcting typos that exist in the project and adding any missing data. All the contribution proposals will be addressed within 30 working days after the OSORI Steering Committee confirms their integrity in terms of data and decides whether to reflect them or not. All the contributions are made through the project Github (link). You can create request for review for your contribution by creating a GitHub issue for data addition/modification, bug report, opinion, function proposal, and PR for any document translation.
 
-Jekyll builds this Just the Docs theme docs website using the theme itself. These web pages show how your web pages will look *by default* when you use this theme. But you can easily *customize* the theme to make them look completely different!
+Below is more detail description for you to clarify all the contribution types as well as ways to participate in the OSORI project.
 
-Browse the docs to learn more about how to use this theme.
+### Data Addition/Modification
+When there is information about an open source and license that you want to add to the OSORI project or when requesting modification of existing data, please proceed your contribution as follows.
 
-## Getting started
+1. Select [New Issue] in the Issue tab from the OSORI GitHub repository.
+2. Select [Get Started] for Data Contribution among the types of issues.
+3. Fill in required information in the issue template, such as the name of Open Source, license, version, and download repository address.
+4. If necessary, write additional explanations in Description (ex. write the content of the error that you request the data correction).
+5. After the above steps, select [Submit new issue].
 
-The [Just the Docs Template] provides the simplest, quickest, and easiest way to create a new website that uses the Just the Docs theme. To get started with creating a site, just click "[use the template]"!
+### Bug Report (including typo correction)
+You can report bugs as an issue while participating in the OSORI project.
 
-{: .note }
-To use the theme, you do ***not*** need to clone or fork the [Just the Docs repo]! You should do that only if you intend to browse the theme docs locally, contribute to the development of the theme, or develop a new theme based on Just the Docs.
+1. Select [New Issue] in the Issue tab from the OSORI GitHub repository.
+2. Select [Get Started] for Bug Report among the types of issues.
+3. Fill in the bug description, its reproduction process, and expected result according to the template, then select [Submit new issue].
 
-You can easily set the site created by the template to be published on [GitHub Pages] – the [template README] file explains how to do that, along with other details.
+### Opinion and feature suggestion
+If there are points of feature improvement that are needed in your usage, you can suggest it as your opinions.
 
-If [Jekyll] is installed on your computer, you can also build and preview the created site *locally*. This lets you test changes before committing them, and avoids waiting for GitHub Pages.[^2] And you will be able to deploy your local build to a different platform than GitHub Pages.
+1. Select [New Issue] in the Issue tab from the OSORI GitHub repository.
+2. Select [Get Started] for Suggestion among the types of issues.
+3. Write your comment as a suggestion in the Description field, then select [Submit new issue].
 
-
-[Jekyll]: https://jekyllrb.com
-[Markdown]: https://daringfireball.net/projects/markdown/
-[Liquid]: https://github.com/Shopify/liquid/wiki
-[Front matter]: https://jekyllrb.com/docs/front-matter/
-[Jekyll configuration]: https://jekyllrb.com/docs/configuration/
-[source file for this page]: https://github.com/just-the-docs/just-the-docs/blob/main/index.md
-[Just the Docs Template]: https://just-the-docs.github.io/just-the-docs-template/
-[Just the Docs]: https://just-the-docs.com
-[Just the Docs repo]: https://github.com/just-the-docs/just-the-docs
-[GitHub Pages]: https://pages.github.com/
-[Template README]: https://github.com/just-the-docs/just-the-docs-template/blob/main/README.md
-[use the template]: https://github.com/just-the-docs/just-the-docs-template/generate
+### Translation
+The OSORI project provides its services in English and Korean. We always welcome any contribution of new language translation in order to better usability globally. For your patches that have been translated, please create a PR for review.

--- a/_i18n/en/guide/guide.md
+++ b/_i18n/en/guide/guide.md
@@ -1,44 +1,86 @@
 # Guide
-{: .fs-9 }
 
-Just the Docs gives your documentation a jumpstart with a responsive Jekyll theme that is easily customizable and hosted on GitHub Pages.
-{: .fs-6 .fw-300 }
+## User Guide
 
-[Get started now](#getting-started){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
-[View it on GitHub][Just the Docs repo]{: .btn .fs-5 .mb-4 .mb-md-0 }
+### Description about "Restriction" name and "Traffic Light"
+Restriction indicates any usage restrictions about an Open Source Software (OSS) or its license in your usage. There may be multiple restrictions in a single OSS or license.
 
----
+| **Restriction Name** | **Description** | **LEVEL** | **Traffic Light** |
+| --- | --- | --- | --- |
+| Non-Commercial Use | Not allowed for commercial use | 5 | Red |
+| Internal Use Only | Allowed only for internal use in your organization | 4 | Red |
+| No Charge | Not allowed to directly charge for usage | 3 | Yellow |
+| No Sell Software Itself | Prohibits direct sales<br> ex. Font, Common Clauses | 2 | Yellow |
+| No Modification | Prohibits modification | 2 | Yellow |
+| No Change the Name | Prohibits changing the name | 1 | Green |
+| No Advertising | Prohibits advertising | 1 | Green |
+| Platform Limitation | Can be used only on specific platforms<br> ex. Museo Sans Font License: for using Enyo Application | 2 | Yellow |
+| Purpose Restriction | Restricts use for a specific purpose<br> ex. The Happy Bunny License: not allowed for military purposes | 2 | Yellow |
+| Specification Restriction | Restricts use related to specific specifications or standards<br> ex. BUSL-1.1.: Possible to grant use for limited products through<br> "Additional Use Grant" (indicated in License Header) | 2 | Yellow |
+| Redistribution Restriction | Restricts subcomponents of software that can be redistributed<br> (source code, binary files, etc.) | 2 | Yellow |
+| Contract Required | Requires contract<br> ex. commercial software | 5 | Red |
+| Provide Installation Information Required | Requires a duty to provide its installation information<br> ex. GPL-3.0 | 4 | Red |
+| Patent Warning | Possibility under a patent dispution (e.g., FFmpeg, APSL)<br> ex. Patent grant is terminated if a lawsuit is filed against "Apple",<br> instead of the patent itself under APSL. | 4 | Red |
+| Network Triggered | Must comply the obligations even using as a network server<br> ex. AGPL-3.0 | 3 | Yellow |
+| Semi-Copyleft | Restrictions can be nullified by disclosing the code<br> (Copyright holder's requests depending on a distribution type)<br> ex. RUBY | 3 | Yellow |
 
-{: .warning }
-> This website documents the features of the current `main` branch of the Just the Docs theme. See the CHANGELOG for a list of releases, new features, and bug fixes.
+- Level: Indicates severity between 1 to 5, according to a degree of attention needed in your commercial usage.
+- Traffic Light: Color display according to Level
+  - 1: Green
+  - 2-3: Yellow
+  - 4-5: Red
 
-Just the Docs is a theme for generating static websites with [Jekyll]. You can write source files for your web pages using [Markdown], the [Liquid] templating language, and HTML.[^1] Jekyll builds your site by converting all files that have [front matter] to HTML. Your [Jekyll configuration] file determines which theme to use, and sets general parameters for your site, such as the URL of its home page.
+### Definition of entities in "License" data table
+- Name: Name of the given License (full name if it's SPDX License)
+- nicknameList: List of alternative names indicating the given License
+- spdx_identifier: Identifier from https://spdx.org/licenses/
+- license_text: Original text of the given License
+- osi_approval: Whether the License has been approved by OSI (https://opensource.org/licenses/)
+- description: Description on the given License (in English)
+- description_ko: Description on the given License (in Korean)
+- obligation_disclosing_src: Scope of source code disclosure in its distribution
 
-Jekyll builds this Just the Docs theme docs website using the theme itself. These web pages show how your web pages will look *by default* when you use this theme. But you can easily *customize* the theme to make them look completely different!
+| **Category** | **Scope of disclosure and its example** |
+| --- | --- |
+| NONE | No obligation to disclose |
+| ORIGINAL | Original open source |
+| FILE | ex. MPL |
+| MODULE | ex. EPL |
+| LIBRARY | ex. LGPL |
+| DERIVATIVE WORK | ex. the given License specifies to disclose derivative work like EUPL |
+| EXECUTABLE | ex. GPL |
+| DATA | ex. CDLA-Sharing-1.0 |
+| SOFTWARE USING THIS | ex. SSPL, Sleepycat |
+| UNSPECIFIED | Disclosure is required, but its scope is unclear |
 
-Browse the docs to learn more about how to use this theme.
+- obligation_notification: Obligation of notification in distribution
+  - false: Obligation of notification is not existed.
+  - true: Obligation of notification is existed.
+- webpage: Representative web link for the given License
+- webpageList: Additional web links aside from "webpage" above for the given License
+- restrictionList: Constraints condition
 
-## Getting started
-
-The [Just the Docs Template] provides the simplest, quickest, and easiest way to create a new website that uses the Just the Docs theme. To get started with creating a site, just click "[use the template]"!
-
-{: .note }
-To use the theme, you do ***not*** need to clone or fork the [Just the Docs repo]! You should do that only if you intend to browse the theme docs locally, contribute to the development of the theme, or develop a new theme based on Just the Docs.
-
-You can easily set the site created by the template to be published on [GitHub Pages] – the [template README] file explains how to do that, along with other details.
-
-If [Jekyll] is installed on your computer, you can also build and preview the created site *locally*. This lets you test changes before committing them, and avoids waiting for GitHub Pages.[^2] And you will be able to deploy your local build to a different platform than GitHub Pages.
-
-
-[Jekyll]: https://jekyllrb.com
-[Markdown]: https://daringfireball.net/projects/markdown/
-[Liquid]: https://github.com/Shopify/liquid/wiki
-[Front matter]: https://jekyllrb.com/docs/front-matter/
-[Jekyll configuration]: https://jekyllrb.com/docs/configuration/
-[source file for this page]: https://github.com/just-the-docs/just-the-docs/blob/main/index.md
-[Just the Docs Template]: https://just-the-docs.github.io/just-the-docs-template/
-[Just the Docs]: https://just-the-docs.com
-[Just the Docs repo]: https://github.com/just-the-docs/just-the-docs
-[GitHub Pages]: https://pages.github.com/
-[Template README]: https://github.com/just-the-docs/just-the-docs-template/blob/main/README.md
-[use the template]: https://github.com/just-the-docs/just-the-docs-template/generate
+### Definition of entities in "OSS" data table
+- name: Name of the given OSS
+  - It is the same as in purl (https://github.com/package-url/purl-spec).
+- **`nicknameList`**: List of alternative names indicating the given OSS
+- homepage: Homepage of the given OSS
+- download_location: Representative link to download the given OSS
+- purl: Package URL (purl) representing the representative link to the given OSS (https://github.com/package-url/purl-spec)
+- **`downloadLocationList`**: Additional links to download the given OSS
+- **`purlList`** : List of Package URLs corresponding to downloadLocationList
+- description: Summary description of the given OSS
+- compliance_notice: Summary description of the given OSS in terms of compliance in English<br>(Additional info. regarding compliance not described in Restriction)
+- compliance_notice_ko: Summary description of the given OSS in terms of compliance in Korean<br>(Additional info. regarding compliance not described in Restriction)
+- **`version_license_diff`**: True if its license is different according to the release version.
+- **`attribution`**: Matters requiring separate notification
+- **`publisher`**: Distributor or owner (personel or organization)
+- **`oss_version`: Information per a version of the given OSS**
+  - version: Version number
+  - description: Summary explanation per version (in English)
+  - description_ko: Summary explanation per version (in Korean)
+  - license_combination: Logical relationship of dual or multiple licenses indicated in declaredLicenseList (possible values: AND, OR, null)
+  - `declaredLicenseList`: Representative license of the given OSS
+  - `detectedLicenseList`: Additional licenses detected aside from declaredLicense in the given OSS
+  - `restrictionList`: Constraints
+  - release_date: Release date

--- a/_i18n/en/license/license.md
+++ b/_i18n/en/license/license.md
@@ -1,6 +1,6 @@
 # License
 
-## License according to a form of our assets
+## License policy according to disclosing form of our assets
 1. Open source information data: ODC-By 1.0 License (Open Data Commons Attribution License v1.0)
 2. Source code: Apache 2.0 License
 3. Contents excluding the open source information data and the source code: CC-BY-2.0 License
@@ -9,9 +9,11 @@
 
 {: .warning }
 > **Restrictions on excessive traffic** <br>
-The information provided by the OSORI Project can be used complimentary by anyone under the above license. However, if a user leads to the excessive traffic on our server, the service may be interrupted, and we may restrict the concerning user with his/her specific IPs to access the server without prior notice.
+The information provided by the OSORI project can be used complimentary by anyone under the above license.<br>
+However, if a user leads to the excessive traffic on our server, the service may be interrupted,<br>
+and we may restrict the concerning user with his/her specific IPs to access the server without prior notice.
 
 ## Disclaimer of warranties
-- The OSORI Project strives to provide as accurate information as possible through cross-validation. Nevertheless, there may be incorrect information included.
-- The information provided by the OSORI Project cannot be used as a basis for legal disputes.
-- The OSORI Project does not guarantee viability for any type of damage caused by the use of our information data, source codes, and any form of assets.
+- The OSORI project strives to provide as accurate information as possible through cross-validation. Nevertheless, there may be incorrect information included.
+- The information provided by the OSORI project cannot be used as a basis for legal disputes.
+- The OSORI project does not guarantee viability for any type of damage caused by the use of our information data, source codes, and any form of assets.


### PR DESCRIPTION
Applied all the documents in Korean from Notion workspace as of Oct. 24th 15:30 (UTC+9).
- Revision of About in Eng. 
  - Rephrase the data expression in the history
- Init the Charter in Eng. 
  - 1st draft doc commit for Charter in Eng.
  - Revised some description and beautification
- Revision of License in Eng. 
  - Beautification in warning message
  - Revisit the Eng. description for the better readability.
- Init Guide doc. in Eng. 
  - 1st draft commit with beautification.
  - Revision of subtitles
  - (To Do) Sub-session navigation in this doc.
- Init the User API Doc. in Eng. 
  - Title modification for the better readability.
  - Standardization of the description style of APIs.
  - (To Do) Sub-session navigation should be embedded.
- Init the Contribution Guide draft in Eng. 
  - Misc. revision for the better readability.
  - (To Do) Correct the link for the Application form when the form is posted into the repository.